### PR TITLE
Patch for openwrt 21.02 kernel 5.4

### DIFF
--- a/999-add-eip93-crypto-54.patch
+++ b/999-add-eip93-crypto-54.patch
@@ -1,0 +1,43 @@
+--- a/drivers/crypto/Kconfig
++++ b/drivers/crypto/Kconfig
+@@ -13,6 +13,8 @@ if CRYPTO_HW
+ 
+ source "drivers/crypto/allwinner/Kconfig"
+ 
++source "drivers/crypto/mtk-eip93/Kconfig"
++
+ config CRYPTO_DEV_PADLOCK
+ 	tristate "Support for VIA PadLock ACE"
+ 	depends on X86 && !UML
+--- a/drivers/crypto/Makefile
++++ b/drivers/crypto/Makefile
+@@ -1,4 +1,5 @@
+ # SPDX-License-Identifier: GPL-2.0
++obj-$(CONFIG_CRYPTO_DEV_EIP93) += mtk-eip93/
+ obj-$(CONFIG_CRYPTO_DEV_ATMEL_AES) += atmel-aes.o
+ obj-$(CONFIG_CRYPTO_DEV_ATMEL_SHA) += atmel-sha.o
+ obj-$(CONFIG_CRYPTO_DEV_ATMEL_TDES) += atmel-tdes.o
+--- a/drivers/crypto/mtk-eip93/eip93-common.c
++++ b/drivers/crypto/mtk-eip93/eip93-common.c
+@@ -8,8 +8,7 @@
+ #include <crypto/aes.h>
+ #include <crypto/ctr.h>
+ #include <crypto/hmac.h>
+-#include <crypto/sha1.h>
+-#include <crypto/sha2.h>
++#include <crypto/sha.h>
+ #include <linux/delay.h>
+ #include <linux/dma-mapping.h>
+ #include <linux/scatterlist.h>
+--- a/drivers/crypto/mtk-eip93/eip93-aead.c
++++ b/drivers/crypto/mtk-eip93/eip93-aead.c
+@@ -13,8 +13,7 @@
+ #include <crypto/internal/aead.h>
+ #include <crypto/md5.h>
+ #include <crypto/null.h>
+-#include <crypto/sha1.h>
+-#include <crypto/sha2.h>
++#include <crypto/sha.h>
+ 
+ #if IS_ENABLED(CONFIG_CRYPTO_DEV_EIP93_DES)
+ #include <crypto/internal/des.h>


### PR DESCRIPTION
Use instead 999-add-eip93-crypto.patch for openwrt 21.02 